### PR TITLE
[fix] courses is nil if there is no courses in response

### DIFF
--- a/classroom/quickstart/quickstart.rb
+++ b/classroom/quickstart/quickstart.rb
@@ -58,9 +58,13 @@ service.authorization = authorize
 # List the first 10 courses the user has access to.
 response = service.list_courses page_size: 10
 
-puts "Courses:"
-puts "No courses found" if response.courses.empty?
-response.courses.each do |course|
-  puts "- #{course.name} (#{course.id})"
+
+if response.courses.nil?
+  puts "No courses found"
+else
+  puts "Courses:"
+  response.courses.each do |course|
+    puts "- #{course.name} (#{course.id})"
+  end
 end
 # [END classroom_quickstart]


### PR DESCRIPTION
#### ✍️ Why we implement the feature or address the issue?
if there is no courses, `response.courses` will be nil instead of empty array, so chain with `.blank?` method will raise error, and the print logic in next line should not executed also

#### ✍️ How does it implement the feature or address the issue?
chain with `.nil?` method instead, and refactor statement to avoid NoMethod Error

#### 📷 ScreenShot
No

#### ✅ Pull Request for
- [ ] Feature
- [x] Bug
- [ ] Refactor
- [ ] Improve

##### Testing 

- [x] Manual testing done
- [ ] New tests for new code written `Option`
